### PR TITLE
防止历史数值太小界面无显示效果

### DIFF
--- a/UI/Controls/Charts/ChartsItemTypeMonth.cs
+++ b/UI/Controls/Charts/ChartsItemTypeMonth.cs
@@ -124,7 +124,11 @@ namespace UI.Controls.Charts
             //{
             //    ValueBlockObj.Width = ValueBlockObj.Height = (Data.Value / MaxValue) * ActualWidth;
             //};
-            ValueBlockObj.Width = ValueBlockObj.Height = (Data.Value / MaxValue) * ActualWidth;
+
+            double size = (Data.Value / MaxValue) * ActualWidth;
+            if (size > 0 && size < 8) //防止历史数值太小界面无显示效果
+                size = 8;
+            ValueBlockObj.Width = ValueBlockObj.Height = size;
             ToolTip = Data.DateTime.ToString("yyyy年MM月dd日") + " " + (string.IsNullOrEmpty(Data.Tag) ? "无数据" : Data.Tag);
 
             if (Data.DateTime.Date == DateTime.Now.Date)


### PR DESCRIPTION
历史数据计算后ValueBlockObj的长宽如果太小，肉眼无法辨识，测试最小8为肉眼可辨识的显示效果。
只是一个建议，可能有更好的办法实现。

修改前：
![image](https://user-images.githubusercontent.com/10232727/148558759-a27c8b69-008a-4da7-8ea2-92ae809d5bc9.png)

修改后：
![image](https://user-images.githubusercontent.com/10232727/148558831-d996e93b-b637-447f-b4b5-18d8188d44a8.png)