### PR TITLE
feat: 统计页添加自动分类

### DIFF
--- a/Core/Models/Config/BehaviorModel.cs
+++ b/Core/Models/Config/BehaviorModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Core.Models.Config.Category;
 
 namespace Core.Models.Config
 {
@@ -17,7 +18,7 @@ namespace Core.Models.Config
         /// </summary>
         public List<string> IgnoreProcessList { get; set; } = new List<string>();
 
-        [Config(IsCanImportExport = true, Name = "匹配规则", NameAddition = "分类名称", Description = "文件夹路径或正则表达式对进程进行匹配", Group = "自动分类", Placeholder = "匹配规则，输入文件夹路径或正则表达式", PlaceholderAddition = "分组名")]
-        public List<KeyValuePair<string, int>> AutoCategoryProcessList { get; set; } = new List<KeyValuePair<string, int>>();
+        [Config(IsCanImportExport = true, Name = "匹配规则", Description = "文件夹路径或正则表达式对进程进行匹配", Group = "自动分类")]
+        public List<AutoCategoryModel> AutoCategoryProcessList { get; set; } = new List<AutoCategoryModel>();
     }
 }

--- a/Core/Models/Config/BehaviorModel.cs
+++ b/Core/Models/Config/BehaviorModel.cs
@@ -16,5 +16,8 @@ namespace Core.Models.Config
         /// 忽略的进程列表
         /// </summary>
         public List<string> IgnoreProcessList { get; set; } = new List<string>();
+
+        [Config(IsCanImportExport = true, Name = "匹配规则", NameAddition = "分类名称", Description = "文件夹路径或正则表达式对进程进行匹配", Group = "自动分类", Placeholder = "匹配规则，输入文件夹路径或正则表达式", PlaceholderAddition = "分组名")]
+        public List<KeyValuePair<string, int>> AutoCategoryProcessList { get; set; } = new List<KeyValuePair<string, int>>();
     }
 }

--- a/Core/Models/Config/Category/AutoCategoryModel.cs
+++ b/Core/Models/Config/Category/AutoCategoryModel.cs
@@ -1,0 +1,14 @@
+﻿namespace Core.Models.Config.Category
+{
+    public class AutoCategoryModel
+    {
+        // [Config(Name = "匹配规则", Placeholder = "匹配规则，输入文件夹路径或正则表达式")]
+        public string RegexRule;
+
+        // [Config(Name = "目标分类", Placeholder = "进程名称，不需要输入.exe。支持正则表达式")]
+        public int CategoryID;
+
+        public string CategoryName;
+
+    }
+}

--- a/Core/Models/Config/ConfigAttribute.cs
+++ b/Core/Models/Config/ConfigAttribute.cs
@@ -15,7 +15,6 @@ namespace Core.Models.Config
     public class ConfigAttribute : System.Attribute
     {
         public string Name;
-        public string NameAddition; // 用于 RenderStringPairList ，表示第二项的名称
         public string Description;
         public string ToggleTrueText;
         public string ToggleFalseText;
@@ -23,7 +22,6 @@ namespace Core.Models.Config
         public int Index;
         public bool IsName;
         public string Placeholder;
-        public string PlaceholderAddition; // 用于 RenderStringPairList，表示第二项的 Placeholder
         public bool IsCanRepeat;
         public bool IsCanImportExport;
         public string Options;

--- a/Core/Models/Config/ConfigAttribute.cs
+++ b/Core/Models/Config/ConfigAttribute.cs
@@ -15,6 +15,7 @@ namespace Core.Models.Config
     public class ConfigAttribute : System.Attribute
     {
         public string Name;
+        public string NameAddition; // 用于 RenderStringPairList ，表示第二项的名称
         public string Description;
         public string ToggleTrueText;
         public string ToggleFalseText;
@@ -22,6 +23,7 @@ namespace Core.Models.Config
         public int Index;
         public bool IsName;
         public string Placeholder;
+        public string PlaceholderAddition; // 用于 RenderStringPairList，表示第二项的 Placeholder
         public bool IsCanRepeat;
         public bool IsCanImportExport;
         public string Options;

--- a/Core/Servicers/Instances/Categorys.cs
+++ b/Core/Servicers/Instances/Categorys.cs
@@ -34,7 +34,7 @@ namespace Core.Servicers.Instances
         {
             using (var db = new TaiDbContext())
             {
-                var item = db.Categorys.Where(m => m.ID == category.ID).FirstOrDefault();
+                var item = GetCategoryByID(category.ID);
                 if (item != null)
                 {
                     db.Categorys.Remove(item);
@@ -50,9 +50,13 @@ namespace Core.Servicers.Instances
             return this._categories;
         }
 
-        public CategoryModel GetCategory(int id)
+        public CategoryModel GetCategoryByID(int id)
         {
             return _categories.Where(m => m.ID == id).FirstOrDefault();
+        }
+        public CategoryModel GetCategoryByName(string name)
+        {
+            return _categories.Where(m => m.Name == name).FirstOrDefault();
         }
 
         public void Load()

--- a/Core/Servicers/Instances/Data.cs
+++ b/Core/Servicers/Instances/Data.cs
@@ -13,6 +13,7 @@ using Npoi.Mapper;
 using System.IO;
 using CsvHelper;
 using System.Globalization;
+using Core.Models.Config.Category;
 
 namespace Core.Servicers.Instances
 {
@@ -369,14 +370,14 @@ namespace Core.Servicers.Instances
                         };
                     }
 
-                    foreach (KeyValuePair<string, int> rule in
+                    foreach (AutoCategoryModel rule in
                              appConfig.GetConfig().Behavior.AutoCategoryProcessList)
                     {
-                        if (RegexHelper.IsMatch(appData.GetApp(item.AppId).File, rule.Key))
+                        if (RegexHelper.IsMatch(appData.GetApp(item.AppId).File, rule.RegexRule))
                         {
                             return new CategoryHoursDataModel()
                             {
-                                CategoryID = rule.Value,
+                                CategoryID = rule.CategoryID,
                                 Total = item.Total,
                                 Time = item.Time
                             };
@@ -417,7 +418,7 @@ namespace Core.Servicers.Instances
                     "from HoursLogModels join AppModels on AppModels.ID=HoursLogModels.AppModelID " +
                     "where HoursLogModels.DataTime>='" + date.Date.ToString("yyyy-MM-dd HH:mm:ss") +
                     "' and HoursLogModels.DataTime<= '" + date.Date.ToString("yyyy-MM-dd 23:59:59") +
-                    "' GROUP BY AppModels.CategoryID,HoursLogModels.DataTime "
+                    "' GROUP BY AppModels.ID, HoursLogModels.DataTime "
                 ).ToList());
 
                 // 无 Time 数据!
@@ -480,7 +481,7 @@ namespace Core.Servicers.Instances
                             "where  DailyLogModels.Date>='" +
                             start.Date.ToString("yyyy-MM-dd HH:mm:ss") + "' and DailyLogModels.Date<= '" +
                             end.Date.ToString("yyyy-MM-dd HH:mm:ss") +
-                            "' GROUP BY AppModels.CategoryID,DailyLogModels.Date ")
+                            "' GROUP BY AppModels.ID, DailyLogModels.Date ")
                         .ToList());
 
                 // 无 Time 数据!
@@ -551,7 +552,7 @@ namespace Core.Servicers.Instances
                     "where DailyLogModels.Date>='" +
                     dateArr[0].Date.ToString("yyyy-MM-dd HH:mm:ss") + "' and DailyLogModels.Date<= '" +
                     dateArr[1].Date.ToString("yyyy-MM-dd HH:mm:ss") +
-                    "' GROUP BY AppModels.CategoryID,DailyLogModels.Date ").ToList());
+                    "' GROUP BY AppModels.ID, DailyLogModels.Date ").ToList());
 
 
                 // 无 Time 数据!

--- a/Core/Servicers/Instances/Data.cs
+++ b/Core/Servicers/Instances/Data.cs
@@ -475,7 +475,7 @@ namespace Core.Servicers.Instances
                             "sum(Time) as Total," +
                             "AppModels.CategoryID," +
                             "AppModels.ID as AppId, " +
-                            "lDailyLogModels.Date as Time " +
+                            "DailyLogModels.Date as Time " +
                             "from DailyLogModels join AppModels on AppModels.ID=DailyLogModels.AppModelID " +
                             "where  DailyLogModels.Date>='" +
                             start.Date.ToString("yyyy-MM-dd HH:mm:ss") + "' and DailyLogModels.Date<= '" +

--- a/Core/Servicers/Interfaces/ICategorys.cs
+++ b/Core/Servicers/Interfaces/ICategorys.cs
@@ -18,7 +18,8 @@ namespace Core.Servicers.Interfaces
         /// 加载已存储的分类数据，仅建议在启动时调用一次，无必要请勿再次调用
         /// </summary>
         void Load();
-        CategoryModel GetCategory(int id);
+        CategoryModel GetCategoryByID(int id);
+        CategoryModel GetCategoryByName(string name);
         CategoryModel Create(CategoryModel category);
         void Update(CategoryModel category);
         void Delete(CategoryModel category);

--- a/UI/Controls/Window/DefaultWindow.cs
+++ b/UI/Controls/Window/DefaultWindow.cs
@@ -205,7 +205,7 @@ namespace UI.Controls.Window
             if (Icon == null)
             {
                 Icon = ToImageSource(System.Drawing.Icon.ExtractAssociatedIcon(
-             System.Reflection.Assembly.GetEntryAssembly().ManifestModule.Name));
+             System.Reflection.Assembly.GetEntryAssembly().ManifestModule.FullyQualifiedName));
             }
 
             Loaded += window_Loaded;

--- a/UI/ViewModels/CategoryPageVM.cs
+++ b/UI/ViewModels/CategoryPageVM.cs
@@ -65,7 +65,7 @@ namespace UI.ViewModels
             {
                 return;
             }
-            var category = categorys.GetCategory(SelectedItem.Data.ID);
+            var category = categorys.GetCategoryByID(SelectedItem.Data.ID);
             if (category != null)
             {
                 categorys.Delete(category);
@@ -184,7 +184,7 @@ namespace UI.ViewModels
                 }
                 mainVM.Toast("已更新", Controls.Window.ToastType.Success);
 
-                var category = categorys.GetCategory(SelectedItem.Data.ID);
+                var category = categorys.GetCategoryByID(SelectedItem.Data.ID);
                 if (category != null)
                 {
                     category.Name = EditName;

--- a/UI/ViewModels/ChartPageVM.cs
+++ b/UI/ViewModels/ChartPageVM.cs
@@ -228,7 +228,7 @@ namespace UI.ViewModels
                 };
                 foreach (var item in list)
                 {
-                    var category = categorys.GetCategory(item.CategoryID);
+                    var category = categorys.GetCategoryByID(item.CategoryID);
                     if (item.CategoryID == 0)
                     {
                         category = nullCategory;
@@ -304,7 +304,7 @@ namespace UI.ViewModels
 
                 foreach (var item in list)
                 {
-                    var category = categorys.GetCategory(item.CategoryID);
+                    var category = categorys.GetCategoryByID(item.CategoryID);
                     if (item.CategoryID == 0)
                     {
                         category = nullCategory;
@@ -383,7 +383,7 @@ namespace UI.ViewModels
 
                 foreach (var item in list)
                 {
-                    var category = categorys.GetCategory(item.CategoryID);
+                    var category = categorys.GetCategoryByID(item.CategoryID);
                     if (item.CategoryID == 0)
                     {
                         category = nullCategory;
@@ -458,7 +458,7 @@ namespace UI.ViewModels
 
                 foreach (var item in list)
                 {
-                    var category = categorys.GetCategory(item.CategoryID);
+                    var category = categorys.GetCategoryByID(item.CategoryID);
                     if (item.CategoryID == 0)
                     {
                         category = nullCategory;

--- a/UI/ViewModels/SettingPageVM.cs
+++ b/UI/ViewModels/SettingPageVM.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Core.Models;
 using UI.Controls;
 using UI.Models;
 
@@ -22,16 +23,23 @@ namespace UI.ViewModels
         private readonly IAppConfig appConfig;
         private readonly MainViewModel mainVM;
         private readonly IData data;
+        private readonly ICategorys categorys;
         public Command OpenURL { get; set; }
         public Command CheckUpdate { get; set; }
         public Command DelDataCommand { get; set; }
         public Command ExportDataCommand { get; set; }
 
-        public SettingPageVM(IAppConfig appConfig, MainViewModel mainVM, IData data)
+        public List<CategoryModel> GetCategories()
+        {
+            return categorys.GetCategories();
+        }
+
+        public SettingPageVM(IAppConfig appConfig, MainViewModel mainVM, IData data, ICategorys categorys)
         {
             this.appConfig = appConfig;
             this.mainVM = mainVM;
             this.data = data;
+            this.categorys = categorys;
 
             OpenURL = new Command(new Action<object>(OnOpenURL));
             CheckUpdate = new Command(new Action<object>(OnCheckUpdate));

--- a/UI/Views/SettingPage.xaml
+++ b/UI/Views/SettingPage.xaml
@@ -20,9 +20,7 @@
                 BorderThickness="0"
                 Margin="0,15,0,0"
                 Padding="0"
-                Background="Transparent"
-            
-                >
+                Background="Transparent">
             <TabControl.Resources>
                 <Style TargetType="TabItem">
                     <Setter Property="Template">


### PR DESCRIPTION
> 希望分类也能支持路径正则表达式，比如把 steam 库路径添加到游戏分类，之后打开 steam 游戏自动计入游戏分类时间。
[#91](https://github.com/Planshit/Tai/issues/91#issuecomment-1372982134)

在`设置-行为-自动分类`中增加匹配规则和对应的 CatelogyID，软件在渲染统计页面时会将对应的软件看作是该分类。

目前自动分类的操作在 `Core/Servicers/Instances/Data.cs` 中查询对应数据时实现。


<img width="602" alt="image" src="https://user-images.githubusercontent.com/11132880/212318637-54b8c13f-9d3c-4cec-b0db-7fd5874e1a04.png">
<img width="533" alt="image" src="https://user-images.githubusercontent.com/11132880/212318744-696c63e8-069c-42de-8e70-28395667895a.png">

目前界面细节仍然需要打磨，先开个 Draft 方便讨论

Signed-off-by: mslxl <i@mslxl.com>