### PR TITLE
修复异步处理事件导致的偶发统计不正确问题

### DIFF
--- a/Core/Models/AppObserver/AppObserverEventArgs.cs
+++ b/Core/Models/AppObserver/AppObserverEventArgs.cs
@@ -12,17 +12,20 @@ namespace Core.Models.AppObserver
         private string _processName;
         private string _description;
         private string _file;
+        private long _eventTicks;
 
         public string ProcessName { get { return _processName; } }
         public string Description { get { return _description; } }
         public string File { get { return _file; } }
         public IntPtr Handle { get { return _handle; } }
-        public AppObserverEventArgs(string processName, string description, string file, IntPtr handle)
+        public long EventTicks { get { return _eventTicks; } }
+        public AppObserverEventArgs(string processName, string description, string file, IntPtr handle, long eventTicks)
         {
             _processName = processName;
             _description = description;
             _file = file;
             _handle = handle;
+            _eventTicks = eventTicks;
         }
     }
 }

--- a/Core/Servicers/Instances/AppObserver.cs
+++ b/Core/Servicers/Instances/AppObserver.cs
@@ -31,15 +31,16 @@ namespace Core.Servicers.Instances
             winEventDelegate, 0, 0, 0);
 
             var window = Win32API.GetForegroundWindow();
-            Handle(window);
+            Handle(window, DateTime.Now.Ticks);
         }
 
         private void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
         {
-            Handle(hwnd);
+            long eventTicks = DateTime.Now.Ticks;
+            Handle(hwnd, eventTicks);
         }
 
-        private async void Handle(IntPtr hwnd)
+        private async void Handle(IntPtr hwnd, long eventTicks)
         {
             string processName = String.Empty, processFileName = String.Empty, processDescription = String.Empty;
 
@@ -104,7 +105,7 @@ namespace Core.Servicers.Instances
                 return processName;
             });
 
-            EventInvoke(processName, processDescription, processFileName, hwnd);
+            EventInvoke(processName, processDescription, processFileName, hwnd, eventTicks);
         }
 
         /// <summary>
@@ -172,9 +173,9 @@ namespace Core.Servicers.Instances
             }
             return new string[] { processName, processFileName, processID.ToString() };
         }
-        private void EventInvoke(string processName, string description, string filename, IntPtr handle)
+        private void EventInvoke(string processName, string description, string filename, IntPtr handle, long eventTicks)
         {
-            var args = new AppObserverEventArgs(processName, description, filename, handle);
+            var args = new AppObserverEventArgs(processName, description, filename, handle, eventTicks);
             OnAppActive?.Invoke(args);
         }
 

--- a/Core/Servicers/Instances/Main.cs
+++ b/Core/Servicers/Instances/Main.cs
@@ -61,6 +61,11 @@ namespace Core.Servicers.Instances
         private SleepStatus sleepStatus;
 
         /// <summary>
+        /// 上次处理的事件的ticks
+        /// </summary>
+        private long lastHandledEventTicks = long.MinValue;
+
+        /// <summary>
         /// app config
         /// </summary>
         private ConfigModel config;
@@ -343,6 +348,13 @@ namespace Core.Servicers.Instances
             {
                 return;
             }
+
+            if (args.EventTicks < lastHandledEventTicks)
+            {
+                Logger.Info("Later event has been handled, drop this event, name:" + args.ProcessName + ", hwnd:" + args.Handle);
+                return;
+            }
+            lastHandledEventTicks = args.EventTicks;
 
             string lastActiveProcess = activeProcess != null ? activeProcess.ToString() : "";
 


### PR DESCRIPTION
异步处理win事件，触发AppObserver_OnAppActive时不一定能保证事件先后顺序，例如：

---
[Info] 2023-09-06 12:16:33
接收到event，hwnd:65930,eventTicks:638295993933216651
Line:40,File:Tai\Servicers\Instances\AppObserver.cs,name:WinEventProc


[Info] 2023-09-06 12:16:33
接收到event，hwnd:525184,eventTicks:638295993933256652
Line:40,File:Tai\Servicers\Instances\AppObserver.cs,name:WinEventProc


[Info] 2023-09-06 12:16:33
Active[True]:msedge,Last:,startTime:2023/9/6 12:16:32,hwnd:525184,dealTicks:638295993933323759
Line:363,File:Tai\Servicers\Instances\Main.cs,name:AppObserver_OnAppActive


[Info] 2023-09-06 12:16:33
已处理过之后的event，丢弃本事件，name:,hwnd:65930,eventTicks:638295993933216651
Line:354,File:Tai\Servicers\Instances\Main.cs,name:AppObserver_OnAppActive

---

先后两个事件，一个是无需统计的hwnd:65930，另一个是我的浏览器hwnd:525184，但AppObserver先处理了hwnd:525184。按原来的流程，会在之后再处理hwnd:65930。处理完成hwnd:65930后，tai认为没有前台程序，而实际上我的前台程序是浏览器hwnd:525184，此时统计结果就不正确了。

此问题在cpu负载较高、频繁切屏、全屏游戏切屏时高发，加入lastHandledEventTicks判定，不再处理“已处理事件”之前的事件，修复此问题。