### PR TITLE
[优化] 性能优化

### DIFF
--- a/Core/Librarys/Browser/Favicon/ChromeFaviconManager.cs
+++ b/Core/Librarys/Browser/Favicon/ChromeFaviconManager.cs
@@ -49,13 +49,13 @@ namespace Core.Librarys.Browser.Favicon
         }
         public async Task<object> GetIconDataAsync(string url)
         {
-            if (string.IsNullOrEmpty(url)) { throw new ArgumentNullException("url"); }
+            if (string.IsNullOrEmpty(url)) { throw new ArgumentNullException(nameof(url)); }
 
             url = UrlHelper.ChromeURLEncode(url);
 
             var result = await Task.Run(() =>
               {
-                  byte[] icon = { };
+                  byte[] icon = Array.Empty<byte>();
                   try
                   {
                       File.Copy(_chromeFaviconsPath, _faviconsTempPath, true);
@@ -96,7 +96,7 @@ namespace Core.Librarys.Browser.Favicon
         private string GetIconId(string url_, SQLiteConnection con_)
         {
             string iconId = string.Empty;
-            string sqlStr = url_.IndexOf("://") == -1 ? $"%{url_}%" : $"{url_}%";
+            string sqlStr = !url_.Contains("://") ? $"%{url_}%" : $"{url_}%";
             using (var cmd = new SQLiteCommand($"select * from icon_mapping where page_url like'{sqlStr}' LIMIT 1", con_))
             {
                 using (SQLiteDataReader dr = cmd.ExecuteReader())
@@ -112,7 +112,7 @@ namespace Core.Librarys.Browser.Favicon
 
         public async Task<string> SaveToLocalIconAsync(object data)
         {
-            if (data == null) { throw new ArgumentNullException("data"); }
+            if (data == null) { throw new ArgumentNullException(nameof(data)); }
             return await Task.Run(() =>
               {
                   var icon = data as byte[];
@@ -120,7 +120,7 @@ namespace Core.Librarys.Browser.Favicon
                   using (var md5 = MD5.Create())
                   {
                       var hash = md5.ComputeHash(icon);
-                      var md5Str = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+                      var md5Str = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
 
                       iconPath = Path.Combine(_taiFaviconsPath, $"{md5Str}.png");
                       if (!File.Exists(iconPath))

--- a/Core/Librarys/Browser/UrlHelper.cs
+++ b/Core/Librarys/Browser/UrlHelper.cs
@@ -10,7 +10,7 @@ namespace Core.Librarys.Browser
 {
     public static class UrlHelper
     {
-        private static readonly Dictionary<string, string> _domainNamesDict = new Dictionary<string, string>()
+        private static readonly Dictionary<string, string> _domainNamesDict = new Dictionary<string, string>(5)
         {
             {"www.google.com","Google" },
             {"github.com","Github" },
@@ -30,13 +30,13 @@ namespace Core.Librarys.Browser
 
             ChromeURLEncode(url_);
 
-            var ph = Regex.Match(url_, @"((https|http|ftp|rtsp|mms)?:\/\/)").Value;
+            var ph = Regex.Match(url_, @"((https|http|ftp|rtsp|mms)?:\/\/)", RegexOptions.Compiled).Value;
             if (!string.IsNullOrEmpty(ph))
             {
                 url_ = url_.Replace(ph, string.Empty);
             }
 
-            int index = url_.IndexOf("/");
+            int index = url_.IndexOf('/');
             if (index != -1)
             {
                 url_ = url_.Substring(0, index);
@@ -57,9 +57,9 @@ namespace Core.Librarys.Browser
             result = GetDomain(result);
 
             //  尝试从已存储的列表中搜索
-            if (_domainNamesDict.ContainsKey(result))
+            if (_domainNamesDict.TryGetValue(result, out var name))
             {
-                return _domainNamesDict[result];
+                return name;
             }
 
             var arr = result.Split('.');
@@ -98,7 +98,7 @@ namespace Core.Librarys.Browser
         {
             url_ = url_.Replace("http://", string.Empty);
             url_ = url_.Replace("https://", string.Empty);
-            return url_.IndexOf("/") == -1;
+            return url_.IndexOf('/') == -1;
         }
 
         /// <summary>
@@ -113,36 +113,36 @@ namespace Core.Librarys.Browser
             {
                 var result = WebUtility.UrlEncode(e.Value);
                 return result;
-            });
+            }, RegexOptions.Compiled);
             //  泰语
             url_ = Regex.Replace(url_, @"[\u0E00-\u0E7F]", (e) =>
             {
                 var result = WebUtility.UrlEncode(e.Value);
                 return result;
-            });
+            }, RegexOptions.Compiled);
             //  德语
             url_ = Regex.Replace(url_, @"[äöüÄÖÜß]", (e) =>
             {
                 var result = WebUtility.UrlEncode(e.Value);
                 return result;
-            });
+            }, RegexOptions.Compiled);
             //  俄语
             url_ = Regex.Replace(url_, @"[ЁёА-я]", (e) =>
             {
                 var result = WebUtility.UrlEncode(e.Value);
                 return result;
-            });
+            }, RegexOptions.Compiled);
             //  中文标点符号
             url_ = Regex.Replace(url_, @"[\u3002|\uff1f|\uff01|\uff0c|\u3001|\uff1b|\uff1a|\u201c|\u201d|\u2018|\u2019|\uff08|\uff09|\u300a|\u300b|\u3008|\u3009|\u3010|\u3011|\u300e|\u300f|\u300c|\u300d|\ufe43|\ufe44|\u3014|\u3015|\u2026|\u2014|\uff5e|\ufe4f|\uffe5]", (e) =>
             {
                 var result = WebUtility.UrlEncode(e.Value);
                 return result;
-            });
+            }, RegexOptions.Compiled);
             return Regex.Replace(url_, @"/[\u4e00-\u9fa5]+|[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]+|[ａ-ｚＡ-Ｚ０-９]+|[々〆〤ヶ]+/u", (e) =>
-             {
-                 var result = WebUtility.UrlEncode(e.Value);
-                 return result;
-             });
+            {
+                var result = WebUtility.UrlEncode(e.Value);
+                return result;
+            }, RegexOptions.Compiled);
 
         }
     }

--- a/Core/Librarys/Iconer.cs
+++ b/Core/Librarys/Iconer.cs
@@ -18,6 +18,7 @@ namespace Core.Librarys
 {
     public class Iconer
     {
+        private static readonly HashSet<char> InvalidCharacterSet = new HashSet<char>(Path.GetInvalidFileNameChars());
         /// <summary>
         /// 格式化图标文件名称
         /// </summary>
@@ -26,22 +27,25 @@ namespace Core.Librarys
         /// <returns>返回正确的文件名称</returns>
         private static string FromatIconFileName(string processname, string desc)
         {
-            string iconName = (processname + desc).Replace(" ", "") + ".png";
+            const string extensionName = ".png";
+            var sb = new StringBuilder(processname.Length + desc.Length + extensionName.Length);
 
             //  清除无效字符
-            iconName = iconName.Replace("/", "");
-            iconName = iconName.Replace("\\", "");
-            iconName = iconName.Replace(":", "");
-            iconName = iconName.Replace("*", "");
-            iconName = iconName.Replace("?", "");
-            iconName = iconName.Replace("\"", "");
-            iconName = iconName.Replace("'", "");
-            iconName = iconName.Replace("<", "");
-            iconName = iconName.Replace(">", "");
-            iconName = iconName.Replace("|", "");
+            AddValidString(processname);
+            AddValidString(desc);
+            sb.Append(extensionName);
 
-            return iconName;
+            return sb.ToString();
+
+            void AddValidString(string text)
+            {
+                foreach (var c in text.Where(c => !InvalidCharacterSet.Contains(c) || c != ' '))
+                {
+                    sb.Append(c);
+                }
+            }
         }
+
         public static string Get(string processname, string desc, bool isRelativePath = true)
         {
             string iconName = FromatIconFileName(processname, desc);

--- a/Core/Librarys/SQLite/SQLiteBuilder.cs
+++ b/Core/Librarys/SQLite/SQLiteBuilder.cs
@@ -152,7 +152,7 @@ namespace Core.Librarys.SQLite
 
                     var modelInfoDb = modelInfosDb.Where(m => m.TableName == tableName);
                     //判断表是否存在
-                    if (modelInfoDb.Count() <= 0)
+                    if (!modelInfoDb.Any())
                     {
                         //不存在则重新创建表
                         string csql = GetCreateTableSQL(model);
@@ -167,7 +167,7 @@ namespace Core.Librarys.SQLite
                         //查找差异属性
                         foreach (var item in model.Properties)
                         {
-                            if (modelDb.Properties.Where(m => m.Name == item.Name).Count() <= 0)
+                            if (modelDb.Properties.Exists(m => m.Name == item.Name))
                             {
                                 string csql = GetCreateColumnSQL(tableName, item);
                                 ExecuteNonQuery(csql);
@@ -186,7 +186,7 @@ namespace Core.Librarys.SQLite
                     string tableName = dbModel.TableName;
 
                     //  查找对应的实体模型
-                    var model = modelInfos.Where(m => m.TableName == tableName).FirstOrDefault();
+                    var model = modelInfos.Find(m => m.TableName == tableName);
 
                     if (model == null)
                     {
@@ -204,7 +204,7 @@ namespace Core.Librarys.SQLite
                         foreach (var dbItem in dbModel.Properties)
                         {
                             //  判断实体模型是否有字段，没有的话需要重建表
-                            if (!model.Properties.Where(m => m.Name == dbItem.Name).Any())
+                            if (!model.Properties.Exists(m => m.Name == dbItem.Name))
                             {
                                 isDel = true;
                                 break;

--- a/Core/Librarys/SiteCache.cs
+++ b/Core/Librarys/SiteCache.cs
@@ -14,7 +14,7 @@ namespace Core.Librarys
         private static readonly int maxNum = 100;
         public static Site Get(string key)
         {
-            return sites.Where(m => m.Title.Equals(key)).FirstOrDefault();
+            return sites.FirstOrDefault(m => m.Title.Equals(key));
         }
 
         public static List<Site> GetAll()

--- a/Core/Servicers/Instances/AppData.cs
+++ b/Core/Servicers/Instances/AppData.cs
@@ -42,7 +42,7 @@ namespace Core.Servicers.Instances
                     .Select(m => new AppModel
                     {
                         ID = m.ID,
-                        Category = m.Category != null ? m.Category : null,
+                        Category = m.Category,
                         CategoryID = m.CategoryID,
                         Description = m.Description,
                         File = m.File,
@@ -87,21 +87,21 @@ namespace Core.Servicers.Instances
         {
             lock (_locker)
             {
-                return _apps.Where(m => m.Name == name).FirstOrDefault();
+                return _apps.Find(m => m.Name == name);
             }
         }
         public AppModel GetApp(int id)
         {
             lock (_locker)
             {
-                return _apps.Where(m => m.ID == id).FirstOrDefault();
+                return _apps.Find(m => m.ID == id);
             }
         }
         public void AddApp(AppModel app)
         {
             lock (_locker)
             {
-                if (_apps.Where(m => m.Name == app.Name).Any())
+                if (_apps.Exists(m => m.Name == app.Name))
                 {
                     return;
                 }

--- a/Core/Servicers/Instances/Categorys.cs
+++ b/Core/Servicers/Instances/Categorys.cs
@@ -34,7 +34,7 @@ namespace Core.Servicers.Instances
         {
             using (var db = new TaiDbContext())
             {
-                var item = db.Categorys.Where(m => m.ID == category.ID).FirstOrDefault();
+                var item = db.Categorys.FirstOrDefault(m => m.ID == category.ID);
                 if (item != null)
                 {
                     db.Categorys.Remove(item);
@@ -52,7 +52,7 @@ namespace Core.Servicers.Instances
 
         public CategoryModel GetCategory(int id)
         {
-            return _categories.Where(m => m.ID == id).FirstOrDefault();
+            return _categories.Find(m => m.ID == id);
         }
 
         public void Load()

--- a/Core/Servicers/Instances/Data.cs
+++ b/Core/Servicers/Instances/Data.cs
@@ -46,7 +46,7 @@ namespace Core.Servicers.Instances
 
                     using (var db = _database.GetWriterContext())
                     {
-                        var app = db.App.Where(m => m.Name == processName_).FirstOrDefault();
+                        var app = db.App.FirstOrDefault(m => m.Name == processName_);
                         if (app == null)
                         {
                             _database.CloseWriter();
@@ -345,9 +345,9 @@ namespace Core.Servicers.Instances
                     var time = date.ToString($"yyyy-MM-dd {hours}:00:00");
                     foreach (var category in categorys)
                     {
-                        var log = data.Where(m => m.CategoryID == category.CategoryID && m.Time.ToString("yyyy-MM-dd HH:00:00") == time).FirstOrDefault();
+                        var log = data.FirstOrDefault(m => m.CategoryID == category.CategoryID && m.Time.ToString("yyyy-MM-dd HH:00:00") == time);
 
-                        var item = list.Where(m => m.CategoryID == category.CategoryID).FirstOrDefault();
+                        var item = list.FirstOrDefault(m => m.CategoryID == category.CategoryID);
 
                         item.Values[i] = log.Total;
                     }
@@ -396,9 +396,9 @@ namespace Core.Servicers.Instances
                     Debug.WriteLine(time);
                     foreach (var category in categorys)
                     {
-                        var log = data.Where(m => m.CategoryID == category.CategoryID && m.Time.ToString("yyyy-MM-dd 00:00:00") == time).FirstOrDefault();
+                        var log = data.FirstOrDefault(m => m.CategoryID == category.CategoryID && m.Time.ToString("yyyy-MM-dd 00:00:00") == time);
 
-                        var item = list.Where(m => m.CategoryID == category.CategoryID).FirstOrDefault();
+                        var item = list.FirstOrDefault(m => m.CategoryID == category.CategoryID);
 
                         item.Values[i] = log.Total;
                     }
@@ -452,7 +452,7 @@ namespace Core.Servicers.Instances
                     {
                         var total = data.Where(m => m.CategoryID == category.CategoryID && m.Time >= dayArr[0] && m.Time <= dayArr[1]).Sum(m => m.Total);
 
-                        var item = list.Where(m => m.CategoryID == category.CategoryID).FirstOrDefault();
+                        var item = list.FirstOrDefault(m => m.CategoryID == category.CategoryID);
 
                         item.Values[i - 1] = total;
                     }
@@ -493,7 +493,7 @@ namespace Core.Servicers.Instances
                     string hours = i < 10 ? "0" + i : i.ToString();
                     var time = date.ToString($"yyyy-MM-dd {hours}:00:00");
 
-                    var log = data.Where(m => m.Time.ToString("yyyy-MM-dd HH:00:00") == time).FirstOrDefault();
+                    var log = data.FirstOrDefault(m => m.Time.ToString("yyyy-MM-dd HH:00:00") == time);
 
 
 
@@ -534,7 +534,7 @@ namespace Core.Servicers.Instances
                     string day = i < 10 ? "0" + i : i.ToString();
                     var time = start.AddDays(i).ToString($"yyyy-MM-dd 00:00:00");
 
-                    var log = data.Where(m => m.Time.ToString("yyyy-MM-dd 00:00:00") == time).FirstOrDefault();
+                    var log = data.FirstOrDefault(m => m.Time.ToString("yyyy-MM-dd 00:00:00") == time);
 
                     item.Values[i] = log.Total;
                 }
@@ -628,10 +628,10 @@ namespace Core.Servicers.Instances
                 mapper.Put(day, "每日");
                 mapper.Put(hours, "时段");
 
-                string name = $"Tai数据({start.ToString("yyyy年MM月")}-{end.ToString("yyyy年MM月")})";
+                string name = $"Tai数据({start:yyyy年MM月}-{end:yyyy年MM月})";
                 if (start.Year == end.Year && start.Month == end.Month)
                 {
-                    name = $"Tai数据({start.ToString("yyyy年MM月")})";
+                    name = $"Tai数据({start:yyyy年MM月})";
                 }
                 mapper.Save(Path.Combine(dir, $"{name}.xlsx"));
 
@@ -700,7 +700,7 @@ namespace Core.Servicers.Instances
                     {
                         string hours = i < 10 ? "0" + i : i.ToString();
                         var time = start.ToString($"yyyy-MM-dd {hours}:00:00");
-                        var log = data.Where(m => m.Time.ToString("yyyy-MM-dd HH:00:00") == time).FirstOrDefault();
+                        var log = data.FirstOrDefault(m => m.Time.ToString("yyyy-MM-dd HH:00:00") == time);
                         result[i] = log.Total;
                     }
                     return result;
@@ -718,7 +718,7 @@ namespace Core.Servicers.Instances
                     for (int i = 0; i < days; i++)
                     {
                         var time = start.Date.AddDays(i).ToString($"yyyy-MM-dd 00:00:00");
-                        var log = data.Where(m => m.Time.ToString("yyyy-MM-dd 00:00:00") == time).FirstOrDefault();
+                        var log = data.FirstOrDefault(m => m.Time.ToString("yyyy-MM-dd 00:00:00") == time);
                         result[i] = log.Total;
                     }
 
@@ -737,7 +737,7 @@ namespace Core.Servicers.Instances
 
                 for (int i = 1; i < 13; i++)
                 {
-                    string month = i < 10 ? "0" + i : i.ToString();
+                    //string month = i < 10 ? "0" + i : i.ToString();
                     var dayArr = Time.GetMonthDate(new DateTime(date.Year, i, 1));
                     var total = data.Where(m => m.Time >= dayArr[0] && m.Time <= dayArr[1]).Sum(m => m.Total);
 

--- a/Core/Servicers/Instances/WebData.cs
+++ b/Core/Servicers/Instances/WebData.cs
@@ -74,7 +74,7 @@ namespace Core.Servicers.Instances
                     {
                         //  获取站点信息
                         string domain = UrlHelper.GetDomain(site_.Url);
-                        var site = db.WebSites.Where(m => m.Domain == domain).FirstOrDefault();
+                        var site = db.WebSites.FirstOrDefault(m => m.Domain == domain);
                         Debug.WriteLine("AddUrlBrowseTime 获取站点数据");
 
                         if (site == null)
@@ -96,7 +96,7 @@ namespace Core.Servicers.Instances
                         }
 
                         //  记录
-                        var log = db.WebBrowserLogs.Where(m => m.LogTime == logTime && m.UrlId == url.ID).FirstOrDefault();
+                        var log = db.WebBrowserLogs.FirstOrDefault(m => m.LogTime == logTime && m.UrlId == url.ID);
 
                         if (log != null)
                         {
@@ -205,7 +205,7 @@ namespace Core.Servicers.Instances
 
             //using (var db = _database.GetWriterContext())
             //{
-            var site = db.WebSites.Where(m => m.Domain == domain).FirstOrDefault();
+            var site = db.WebSites.FirstOrDefault(m => m.Domain == domain);
             if (site == null)
             {
                 site = db.WebSites.Add(new WebSiteModel()
@@ -230,7 +230,7 @@ namespace Core.Servicers.Instances
         {
             lock (_createUrlLocker)
             {
-                var result = db.WebUrls.Where(m => m.Url == site_.Url).FirstOrDefault();
+                var result = db.WebUrls.FirstOrDefault(m => m.Url == site_.Url);
                 if (result == null)
                 {
                     result = db.WebUrls.Add(new Models.Db.WebUrlModel()
@@ -431,7 +431,7 @@ namespace Core.Servicers.Instances
         {
             using (var db = _database.GetReaderContext())
             {
-                var result = db.WebSiteCategories.Where(m => m.ID == categoryId_).FirstOrDefault();
+                var result = db.WebSiteCategories.FirstOrDefault(m => m.ID == categoryId_);
                 return result;
             }
         }
@@ -464,7 +464,7 @@ namespace Core.Servicers.Instances
                     for (int i = 0; i < 24; i++)
                     {
                         var time = new DateTime(start_.Year, start_.Month, start_.Day, i, 0, 0);
-                        var item = data.Where(m => m.Time == time).FirstOrDefault();
+                        var item = data.FirstOrDefault(m => m.Time == time);
                         var dataItem = new CommonDataModel()
                         {
                             ID = i,
@@ -563,10 +563,10 @@ namespace Core.Servicers.Instances
                         var time = new DateTime(start_.Year, start_.Month, start_.Day, i, 0, 0);
                         foreach (var category in categories)
                         {
-                            var log = data.Where(m => m.CategoryID == category.CategoryID && m.LogTime == time).FirstOrDefault();
+                            var log = data.FirstOrDefault(m => m.CategoryID == category.CategoryID && m.LogTime == time);
                             if (log != null)
                             {
-                                var resultItem = result.Where(m => m.CategoryID == category.CategoryID).FirstOrDefault();
+                                var resultItem = result.FirstOrDefault(m => m.CategoryID == category.CategoryID);
                                 resultItem.Values[i] = log.Duration;
                             }
                         }
@@ -598,7 +598,7 @@ namespace Core.Servicers.Instances
                             {
                                 var duration = data.Where(m => m.CategoryID == category.CategoryID && m.LogTime >= startTime && m.LogTime <= endTime).Sum(m => m.Duration);
 
-                                var resultItem = result.Where(m => m.CategoryID == category.CategoryID).FirstOrDefault();
+                                var resultItem = result.FirstOrDefault(m => m.CategoryID == category.CategoryID);
                                 resultItem.Values[i] = duration;
                             }
                         }
@@ -624,7 +624,7 @@ namespace Core.Servicers.Instances
                             {
                                 var duration = data.Where(m => m.CategoryID == category.CategoryID && m.LogTime >= startTime && m.LogTime <= endTime).Sum(m => m.Duration);
 
-                                var resultItem = result.Where(m => m.CategoryID == category.CategoryID).FirstOrDefault();
+                                var resultItem = result.FirstOrDefault(m => m.CategoryID == category.CategoryID);
                                 resultItem.Values[i] = duration;
                             }
                         }
@@ -709,7 +709,7 @@ namespace Core.Servicers.Instances
         {
             using (var db = _database.GetReaderContext())
             {
-                var result = db.WebSites.Where(m => m.ID == id_).FirstOrDefault();
+                var result = db.WebSites.FirstOrDefault(m => m.ID == id_);
                 return result;
             }
         }
@@ -718,7 +718,7 @@ namespace Core.Servicers.Instances
         {
             using (var db = _database.GetReaderContext())
             {
-                var result = db.WebSites.Where(m => m.Domain.ToLower() == domain.ToLower()).FirstOrDefault();
+                var result = db.WebSites.FirstOrDefault(m => m.Domain.ToLower() == domain.ToLower());
                 return result;
             }
         }


### PR DESCRIPTION
1. 在 `Iconer.FromatIconFileName` 中使用 `StringBuilder` 代替多次 `string.Replace` 调用, 减少字符串分配次数
2. `string.IndexOf("xxx")` 改为 `string.Contains()` 方法
3. ArgumentNullException 的 `paramName` 参数从硬编码改为`nameof()`
4. 改用 `Array.Empty<T>()` 获得空数组
5. 将单字符字符串从 `string.IndexOf(string)` 改为 `string.IndexOf(char)` 调用