### PR TITLE
no age shaming

### DIFF
--- a/WebExtensions/Chrome/manifest.json
+++ b/WebExtensions/Chrome/manifest.json
@@ -7,7 +7,7 @@
         "128": "icon128.png"
     },
     "manifest_version": 3,
-    "minimum_chrome_version": "116",
+    "minimum_chrome_version": "1",
     "action": {
         "default_icon": "icons/socket-inactive.png"
     },


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version ___+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)