### PR TITLE
快速切换相邻日期

### DIFF
--- a/UI/Controls/Select/DateSelect.cs
+++ b/UI/Controls/Select/DateSelect.cs
@@ -152,6 +152,7 @@ namespace UI.Controls.Select
         public Command ShowSelectCommand { get; set; }
         public Command SetYearCommand { get; set; }
         public Command SetMonthCommand { get; set; }
+        public Command SwitchDateCommand { get; set; }
         public Command DoneCommand { get; set; }
 
         private bool IsFirstClick = false;
@@ -164,6 +165,7 @@ namespace UI.Controls.Select
             ShowSelectCommand = new Command(new Action<object>(OnShowSelect));
             SetYearCommand = new Command(new Action<object>(OnSetYear));
             SetMonthCommand = new Command(new Action<object>(OnSetMonth));
+            SwitchDateCommand = new Command(new Action<object>(OnSwitchDate));
             DoneCommand = new Command(new Action<object>(OnDone));
 
 
@@ -247,6 +249,30 @@ namespace UI.Controls.Select
             UpdateDateStr();
 
             IsOpen = false;
+        }
+
+        private void OnSwitchDate(object obj)
+        {
+            var newDate = Day != null ? Day.Day : new DateTime(Year, Month, 1);
+            if (SelectType == DateSelectType.Day)
+            {
+                newDate = newDate.AddDays(int.Parse(obj.ToString()));
+            }
+            else if (SelectType == DateSelectType.Month)
+            {
+                newDate = newDate.AddMonths(int.Parse(obj.ToString()));
+            }
+            else if (SelectType == DateSelectType.Year)
+            {
+                newDate = newDate.AddYears(int.Parse(obj.ToString()));
+            }
+            Year = newDate.Year;
+            Month = newDate.Month;
+            Date = newDate;
+            SelectedDay = newDate;
+
+            UpdateDays();
+            UpdateDateStr();
         }
 
         private void OnSetMonth(object obj)

--- a/UI/Themes/Select/DateSelect.xaml
+++ b/UI/Themes/Select/DateSelect.xaml
@@ -22,16 +22,20 @@
                                     <DropShadowEffect Color="#d8d2d2" BlurRadius="1" Direction="300" ShadowDepth="4" Opacity="0.1" RenderingBias="Performance" ></DropShadowEffect>
                                 </Border.Effect>
                             </Border>
-                            <Border x:Name="Main" Margin="0,0,0,0" Background="{DynamicResource StandardBackgroundBrush}" HorizontalAlignment="Left" Padding="18,10" CornerRadius="5">
-                                <Border.InputBindings>
-                                    <MouseBinding Gesture="LeftClick" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:DateSelect}}, Path=ShowSelectCommand}"/>
-                                </Border.InputBindings>
+                            <StackPanel Orientation="Horizontal">
+                                <button:IconButton Icon="ChevronLeft" FontSize="12" VerticalAlignment="Center" Margin="0,0,5,0" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:DateSelect}}, Path=SwitchDateCommand}" CommandParameter="-1"/>
+                                <Border x:Name="Main" Margin="0,0,0,0" Background="{DynamicResource StandardBackgroundBrush}" HorizontalAlignment="Left" Padding="18,10" CornerRadius="5">
+                                    <Border.InputBindings>
+                                        <MouseBinding Gesture="LeftClick" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:DateSelect}}, Path=ShowSelectCommand}"/>
+                                    </Border.InputBindings>
 
-                                <StackPanel Orientation="Horizontal">
-                                    <base:Icon x:Name="Icon" IconType="Calendar"  Foreground="{DynamicResource StandardTextBrush}"/>
-                                    <TextBlock Foreground="{DynamicResource StandardTextBrush}" Text="{TemplateBinding DateStr}" VerticalAlignment="Center" Margin="5,0,0,0"/>
-                                </StackPanel>
-                            </Border>
+                                    <StackPanel Orientation="Horizontal">
+                                        <base:Icon x:Name="Icon" IconType="Calendar"  Foreground="{DynamicResource StandardTextBrush}"/>
+                                        <TextBlock Foreground="{DynamicResource StandardTextBrush}" Text="{TemplateBinding DateStr}" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                                    </StackPanel>
+                                </Border>
+                                <button:IconButton Icon="ChevronRight" FontSize="12" VerticalAlignment="Center" Margin="5,0,0,0" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:DateSelect}}, Path=SwitchDateCommand}" CommandParameter="1"/>
+                            </StackPanel>
 
                             <!--选择-->
                             <Popup 


### PR DESCRIPTION
向`DateSelect`控件添加切换按钮，可快速切换日/月/年。
经过本地编译运行过，本人不是C#开发者，如有其他错误或问题请帮忙修改一下。